### PR TITLE
update edit/add collections & rooms modals clickk-off close & cancel …

### DIFF
--- a/src/collection/AddCollection.js
+++ b/src/collection/AddCollection.js
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import CollectionForm from './CollectionForm';
 
-const AddCollection = ({ close }) => {
+const AddCollection = ({ close, setAddCollection }) => {
 
     return(
         <Container maxWidth="md">
@@ -14,7 +14,7 @@ const AddCollection = ({ close }) => {
                         Add Collection
                     </Typography>
                     <p>All fields required.</p>
-                   <CollectionForm close={close} />
+                   <CollectionForm close={close} setAddCollection={setAddCollection} />
                 </Paper>
             </Box>
         </Container>

--- a/src/collection/Collection.js
+++ b/src/collection/Collection.js
@@ -43,7 +43,7 @@ const Collection = ({
     handleDelete, 
     handleRequest, 
     getPlants }) => {
-        
+
     const [ error, rooms, setRooms, handleRoomRequest ] = useRooms();
     const [addCollection, setAddCollection] = useState(false);
     const [editCollection, setEditCollection] = useState(false);
@@ -185,23 +185,23 @@ const Collection = ({
 
                             <Modal
                                 open={editCollection}
-                                onClose={() => handleClose('edit-collection')}
+                                onClose={() => setEditCollection(false)}
                                 aria-labelledby="modal-modal-title"
                                 aria-describedby="modal-modal-description"
                             >
                                 <Box sx={modalStyle}>
-                                    <EditCollection close={handleClose} collection={collection} />
+                                    <EditCollection close={handleClose} setEditCollection={setEditCollection} collection={collection} />
                                 </Box>
                             </Modal>
 
                             <Modal
                                 open={addRoom}
-                                onClose={() => handleClose('add-room')}
+                                onClose={() => setaddRoom(false)}
                                 aria-labelledby="modal-modal-title"
                                 aria-describedby="modal-modal-description"
                             >
                                 <Box sx={modalStyle}>
-                                    <AddRoom close={handleClose} collectionId={collection.id} />
+                                    <AddRoom close={handleClose} setaddRoom={setaddRoom} collectionId={collection.id} />
                                 </Box>
                             </Modal>
 
@@ -327,12 +327,12 @@ const Collection = ({
 
                         <Modal
                             open={addCollection}
-                            onClose={() => handleClose('add-collection')}
+                            onClose={() => setAddCollection(false)}
                             aria-labelledby="modal-modal-title"
                             aria-describedby="modal-modal-description"
                         >
                             <Box sx={modalStyle}>
-                                <AddCollection close={handleClose} />
+                                <AddCollection close={handleClose} setAddCollection={setAddCollection} />
                             </Box>
                         </Modal>
 

--- a/src/collection/CollectionForm.js
+++ b/src/collection/CollectionForm.js
@@ -13,7 +13,7 @@ const validationSchema = yup.object({
         .required('You must enter a name for your collection.'),
 });
 
-const CollectionForm = ({ close, collection=null }) => {
+const CollectionForm = ({ close, setEditCollection, setAddCollection, collection=null }) => {
     const [ error, collections, setCollections, handleCollectionRequest ] = useCollections();
     const [ message, setMessage ] = useState(null);
 
@@ -77,7 +77,7 @@ const CollectionForm = ({ close, collection=null }) => {
                             Submit
                         </Button>
                         <Button 
-                            onClick={() => collection ? close('edit-collection') : close('add-collection')} 
+                            onClick={() => collection ? setEditCollection(false) : setAddCollection(false)} 
                             color="info" sx={{  color: '#fff'}} 
                             variant="contained" 
                             size="large"

--- a/src/collection/EditCollection.js
+++ b/src/collection/EditCollection.js
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import CollectionForm from './CollectionForm';
 
-const EditCollection = ({ close, collection }) => {
+const EditCollection = ({ close, setEditCollection, collection }) => {
     return(
         <Container maxWidth="md">
             <Box sx={{ display: 'flex', flexWrap: 'wrap', '& > :not(style)': { m: 2, p: 2 } }}>
@@ -13,7 +13,7 @@ const EditCollection = ({ close, collection }) => {
                         Edit Collection
                     </Typography>
                     <p>All fields required.</p>
-                   <CollectionForm close={close} collection={collection} />
+                   <CollectionForm close={close} setEditCollection={setEditCollection} collection={collection} />
                 </Paper>
             </Box>
         </Container>

--- a/src/room/AddRoom.js
+++ b/src/room/AddRoom.js
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import RoomForm from './RoomForm';
 
-const AddRoom = ({ close, collectionId }) => {
+const AddRoom = ({ close, setaddRoom, collectionId }) => {
     return(
         <Container maxWidth="md">
             <Box sx={{ display: 'flex', flexWrap: 'wrap', '& > :not(style)': { m: 2, p: 2 } }}>
@@ -13,7 +13,7 @@ const AddRoom = ({ close, collectionId }) => {
                         Add Room
                     </Typography>
                     <p>All fields required.</p>
-                   <RoomForm close={close} collectionId={collectionId} />
+                   <RoomForm close={close} setaddRoom={setaddRoom} collectionId={collectionId} />
                 </Paper>
             </Box>
         </Container>

--- a/src/room/EditRoom.js
+++ b/src/room/EditRoom.js
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import RoomForm from './RoomForm';
 
-const EditRoom = ({ close, room }) => {
+const EditRoom = ({ close, setEditRoom, room }) => {
     return(
         <Container maxWidth="md">
             <Box sx={{ display: 'flex', flexWrap: 'wrap', '& > :not(style)': { m: 2, p: 2 } }}>
@@ -13,7 +13,7 @@ const EditRoom = ({ close, room }) => {
                         Edit Room
                     </Typography>
                     <p>All fields required.</p>
-                   <RoomForm close={close} room={room} />
+                   <RoomForm close={close} setEditRoom={setEditRoom} room={room} />
                 </Paper>
             </Box>
         </Container>

--- a/src/room/Room.js
+++ b/src/room/Room.js
@@ -116,12 +116,12 @@ const Room = ({
                             </ListItem>
                             <Modal
                                 open={editRoom}
-                                onClose={() => handleClose('edit-room')}
+                                onClose={() => setEditRoom(false)}
                                 aria-labelledby="modal-modal-title"
                                 aria-describedby="modal-modal-description"
                             >
                                 <Box sx={modalStyle}>
-                                    <EditRoom close={handleClose} room={room} />
+                                    <EditRoom close={handleClose} setEditRoom={setEditRoom} room={room} />
                                 </Box>
                             </Modal>
                             <WarningModal

--- a/src/room/RoomForm.js
+++ b/src/room/RoomForm.js
@@ -13,7 +13,7 @@ const validationSchema = yup.object({
         .required('You must enter a name for your room.'),
 });
 
-const RoomForm = ({ close, collectionId=null, room=null }) => {
+const RoomForm = ({ close, setaddRoom, setEditRoom, collectionId=null, room=null }) => {
     const [ error, rooms, setRooms, handleRoomRequest ] = useRooms();
     const [ message, setMessage ] = useState(null);
 
@@ -76,7 +76,7 @@ const RoomForm = ({ close, collectionId=null, room=null }) => {
                             Submit
                         </Button>
                         <Button 
-                            onClick={() => room ? close('edit-room') : close('add-room')} 
+                            onClick={() => room ? setEditRoom(false) : setaddRoom(false)} 
                             color="info" 
                             sx={{ color: '#fff'}} 
                             variant="contained"

--- a/src/room/useRooms.js
+++ b/src/room/useRooms.js
@@ -46,7 +46,7 @@ const useRooms = () => {
         const headers = { 'content-type': 'application/json', 'x-access-token': TOKEN };
         try {
             const response = await axios({ url, method, data, headers, params});
-            console.log('useRooms API response:', response);
+            // console.log('useRooms API response:', response);
             if (method !== 'delete') {
                 setError(null);
                 setRooms(response.data);
@@ -55,7 +55,7 @@ const useRooms = () => {
             return { success: true, message };
         } catch (err) {
             const message = err.response.data.msg;
-            console.error('API ERROR:', err);
+            // console.error('API ERROR:', err);
             setError(message);
             return { success: false, message };
         }


### PR DESCRIPTION
Updated edit/add collections & rooms modals click-off close & cancel close to set the modal open state to false so that components do not reload.

Previously I was using the handleClose method which triggers a fetch of new collections/rooms and reloads the components. The handleclose method should only run when the user makes a successful change. This is more expected behavior for user experience.